### PR TITLE
FIX - sprites-camera의 width, height 제거

### DIFF
--- a/assets/stylesheets/pc/app/products/reviews.css.scss
+++ b/assets/stylesheets/pc/app/products/reviews.css.scss
@@ -35,9 +35,9 @@ body.products.reviews, #review-edit-form {
           top: 25px;
           left: 0px;
 
-            .link-review-option-type {
-              color: #000;
-            }
+          .link-review-option-type {
+            color: #000;
+          }
         }
       }
     }
@@ -80,9 +80,7 @@ body.products.reviews, #review-edit-form {
         left: 93px;
       }
 
-      &.photo .sprites-camera{
-        width: 16px;
-        height: 16px;
+      &.photo .sprites-camera {
         display: block;
         position: absolute;
         top: 12.5px;


### PR DESCRIPTION
### 이유
- sprites는 자동 계산되는 width, height를 사용해야하는데 잘못된 값으로 강제되어 있었다.

https://app.asana.com/0/search/292519521653687/302364354074031